### PR TITLE
.env에서 OS 때문에 생기는 이슈 해결

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-SASS_PATH=node_modules:src/assets/scss

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/README.md
+++ b/README.md
@@ -43,6 +43,20 @@ yarn storybook
 
 ## Issue
 
+### .env에서 OS 때문에 생기는 이슈(20.11.24)
+
+각 OS에 맞는 .env 설정이 필요함
+
+```.env
+// .env
+
+// Window 설정
+SASS_PATH=node_modules:./node_modules;./src/assets/scss
+
+// Mac 설정
+SASS_PATH=node_modules:src/assets/scss
+```
+
 ### node-sass 버전때문에 생기는 이슈(20.11.18)
 
 node-sass버전 확인 필요


### PR DESCRIPTION
## Issue❗️
운영체제에 따른 환경변수 `.env` 설정이 달라서 SASS의 절대경로를 못잡는 이슈 발생

## Solution ✅
`.gitignore`에서 `.env`를 추가해주었음. 앞으로 운영체제별로 `.env`를 설정하고 관리를 해야함
```.env
// .env

// Window 설정
SASS_PATH=node_modules:./node_modules;./src/assets/scss

// Mac 설정
SASS_PATH=node_modules:src/assets/scss
```