### PR TITLE
GameSetting 추가 및 Timer 관련 Issue

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import { BrowserRouter, Route, Switch, Redirect } from 'react-router-dom';
 
 import Navbar from '@/components/pages/Navbar';
 import Home from '@/components/pages/Home';
+import GameSetting from '@/components/pages/GameSetting';
 import GamePrepare from '@/components/pages/GamePrepare';
 import Ingame from '@/components/pages/Ingame';
 import Result from '@/components/pages/Result';
@@ -20,6 +21,7 @@ const App = () => {
         <Switch>
           <Route path="/" exact component={Home} />
           <Route path="/gameprepare" exact component={GamePrepare} />
+          <Route path="/gamesetting" exact component={GameSetting} />
           <Route path="/ingame" exact component={Ingame} />
           <Route path="/result/:resultState" exact component={Result} />
           <Route path="/rank" exact component={Rank} />

--- a/src/assets/scss/pages/GameSetting.scss
+++ b/src/assets/scss/pages/GameSetting.scss
@@ -1,0 +1,23 @@
+@import 'utils/variables.scss';
+
+.gamesetting {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  .text__container {
+    margin-top: 2rem;
+    text-align: center;
+    p,
+    h4 {
+      font-weight: $font-weight-bold;
+    }
+    &--title {
+      font-size: $font-size-4;
+      margin-bottom: 1rem;
+    }
+    &--contents {
+      color: $color-orange-1;
+    }
+  }
+}

--- a/src/components/elements/ingame/RoundTimer.js
+++ b/src/components/elements/ingame/RoundTimer.js
@@ -2,33 +2,26 @@ import React from 'react';
 import '@/assets/scss/elements/ingame/RoundTimer.scss';
 import '@/assets/images/round.png';
 
-const RoundTimer = ({ time, isReady }) => {
+const RoundTimer = ({ time }) => {
   return (
-    <>
-      {!isReady ? (
-        <div className="round-timer">
-          <p className="round-timer--number">
-            {time}
-            <span>s</span>
-          </p>
-          <div className="round-timer--inner">
-            <svg>
-              <circle cx="50" cy="50" r="42" />
-              <circle cx="50" cy="50" r="42" />
-            </svg>
-          </div>
-          <div className="round-timer--outer" />
-        </div>
-      ) : (
-        ''
-      )}
-    </>
+    <div className="round-timer">
+      <p className="round-timer--number">
+        {time}
+        <span>s</span>
+      </p>
+      <div className="round-timer--inner">
+        <svg>
+          <circle cx="50" cy="50" r="42" />
+          <circle cx="50" cy="50" r="42" />
+        </svg>
+      </div>
+      <div className="round-timer--outer" />
+    </div>
   );
 };
 
 RoundTimer.defaultProps = {
   time: 120,
-  isReady: false,
 };
 
 export default RoundTimer;

--- a/src/components/elements/nav/BarTimer.js
+++ b/src/components/elements/nav/BarTimer.js
@@ -2,23 +2,25 @@ import React, { useEffect, useState } from 'react';
 
 import '@/assets/scss/elements/nav/BarTimer.scss';
 
-const BarTimer = ({ time, timeout, isActive }) => {
-  const [timerStyle, setTimerStyle] = useState({});
+const BarTimer = ({ timer, timeout, isActive }) => {
+  const [timerStyle, setTimerStyle] = useState({ transitionDuration: `1s` });
   useEffect(() => {
     if (isActive) {
-      setTimerStyle({
-        transitionDuration: `${timeout}s`,
-        width: `100%`,
-      });
+      const progress = ((timeout - timer) / timeout) * 100;
+      if (progress === 80) {
+        setTimerStyle({
+          ...timerStyle,
+          backgroundColor: '#ff5050',
+          width: `${progress}%`,
+        });
+      } else {
+        setTimerStyle({
+          ...timerStyle,
+          width: `${progress}%`,
+        });
+      }
     }
-    if (time / timeout > 0.7) {
-      setTimerStyle({
-        ...timerStyle,
-        transitionDuration: `${timeout * 0.05}s`,
-        backgroundColor: '#FF5050',
-      });
-    }
-  }, [time, timeout]);
+  }, [timer, isActive]);
 
   return (
     <div className="bartimer">
@@ -28,7 +30,7 @@ const BarTimer = ({ time, timeout, isActive }) => {
 };
 
 BarTimer.defaultProps = {
-  time: 0,
+  timer: 100,
   timeout: 100,
   isActive: true,
 };

--- a/src/components/elements/nav/TextTimer.js
+++ b/src/components/elements/nav/TextTimer.js
@@ -2,13 +2,13 @@ import React, { useEffect, useState } from 'react';
 
 import '@/assets/scss/elements/nav/TextTimer.scss';
 
-const TextTimer = ({ time, timeout }) => {
-  const [min, setMin] = useState(setInterval((timeout - time) / 60));
-  const [sec, setSec] = useState((timeout - time) % 60);
+const TextTimer = ({ time }) => {
+  const [min, setMin] = useState(setInterval(time / 60));
+  const [sec, setSec] = useState(time % 60);
   useEffect(() => {
-    setSec((timeout - time) % 60);
-    setMin(parseInt((timeout - time) / 60, 10));
-  }, [time, timeout]);
+    setSec(time % 60);
+    setMin(parseInt(time / 60, 10));
+  }, [time]);
   return (
     <p className="texttimer">
       남은 시간 {(min < 10 ? '0' : '') + min}:{(sec < 10 ? '0' : '') + sec}
@@ -18,7 +18,6 @@ const TextTimer = ({ time, timeout }) => {
 
 TextTimer.defaultProps = {
   time: 0,
-  timeout: 100,
 };
 
 export default TextTimer;

--- a/src/components/layouts/navbar/HeaderBar.js
+++ b/src/components/layouts/navbar/HeaderBar.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Route, Link } from 'react-router-dom';
+import React, { useState, useEffect } from 'react';
+import { Link, useLocation, useHistory } from 'react-router-dom';
 import LogoSvg from '@/assets/images/svg/LogoSvg';
 import Hamburger from '@/components/elements/nav/Hamburger';
 import TextTimer from '@/components/elements/nav/TextTimer';
@@ -8,6 +8,43 @@ import BarTimer from '@/components/elements/nav/BarTimer';
 import '@/assets/scss/layouts/navbar/HeaderBar.scss';
 
 const HeaderBar = ({ navbarRef, hook }) => {
+  const timeOut = 10; // 나중에 리덕스에서 가져와야 하는 부분
+  const location = useLocation();
+  const history = useHistory();
+  const [timer, setTimer] = useState(timeOut);
+  const [isIngame, setIsIngame] = useState(false);
+
+  useEffect(() => {
+    if (isIngame) {
+      const countdown = setInterval(() => {
+        setTimer(timer - 1);
+      }, 1000);
+      return () => {
+        clearInterval(countdown);
+        if (timer < 1) {
+          setIsIngame(false);
+          history.push('/result/fail', { success: false });
+        }
+      };
+    }
+    return false;
+  }, [timer, isIngame]);
+
+  useEffect(() => {
+    switch (location.pathname) {
+      case '/ingame':
+        setTimer(10);
+        setIsIngame(true);
+        break;
+      case '/result/success':
+        // dispatch 해야하는 부분
+        setIsIngame(false);
+        break;
+      default:
+        setIsIngame(false);
+    }
+  }, [location.pathname]);
+
   return (
     <>
       <div className="headerbar">
@@ -15,13 +52,15 @@ const HeaderBar = ({ navbarRef, hook }) => {
           <Link to="/">
             <LogoSvg />
           </Link>
-          <Route path="/ingame" exact component={TextTimer} />
+          {location.pathname === '/ingame' ? <TextTimer time={timer} /> : null}
         </div>
         <div className="headerbar__right">
           <Hamburger el={navbarRef} hook={hook} />
         </div>
       </div>
-      <Route path="/ingame" exact component={BarTimer} />
+      {location.pathname === '/ingame' ? (
+        <BarTimer timer={timer} timeout={timeOut} isActive={isIngame} />
+      ) : null}
     </>
   );
 };

--- a/src/components/pages/GameSetting.js
+++ b/src/components/pages/GameSetting.js
@@ -1,0 +1,42 @@
+import React, { useState, useEffect } from 'react';
+import { isLoading, isSuccess } from '@/modules/status';
+import { useDispatch } from 'react-redux';
+import { useHistory } from 'react-router-dom';
+
+import TopicList from '@/utils/data/topic.json';
+
+import RoundTimer from '@/components/elements/ingame/RoundTimer';
+
+import '@/assets/scss/pages/GameSetting.scss';
+
+const GameSetting = () => {
+  const topicLength = 4;
+  const history = useHistory();
+  const dispatch = useDispatch();
+  const [topic, setTopic] = useState('');
+  const makeTopic = () => {
+    const dummy = TopicList[`length${topicLength}`];
+    setTopic(dummy[Math.floor(Math.random() * dummy.length)]);
+  };
+  useEffect(() => {
+    document.addEventListener('animationend', () => {
+      history.push('/ingame', { topic });
+    });
+  }, []);
+  useEffect(() => {
+    dispatch(isLoading());
+    makeTopic();
+    dispatch(isSuccess());
+  }, [history]);
+  return (
+    <div className="gamesetting">
+      <RoundTimer />
+      <div className="text__container">
+        <p className="text__container--title">주제어</p>
+        <h4 className="text__container--contents">{topic}</h4>
+      </div>
+    </div>
+  );
+};
+
+export default GameSetting;

--- a/src/components/pages/Home.js
+++ b/src/components/pages/Home.js
@@ -1,7 +1,12 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 const Home = () => {
-  return <div>Home</div>;
+  return (
+    <div>
+      <Link to="/gamesetting">gamesetting</Link>
+    </div>
+  );
 };
 
 export default Home;

--- a/src/stories/Timer.stories.js
+++ b/src/stories/Timer.stories.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import BarTimer from '@/components/elements/nav/BarTimer';
 import TextTimer from '@/components/elements/nav/TextTimer';
-import useInterval from '@/utils/hooks/useInterval';
 
 export default {
   title: 'Timer',
@@ -16,32 +15,34 @@ export default {
 };
 
 export const Default = ({ time, start }) => {
+  const timeOut = time || 40;
   const [timer, setTimer] = useState(0);
-  const timeOut = time;
   const [isRunning, setIsRunning] = useState(false);
-  const [change, setChange] = useState(true);
-  useInterval(
-    () => {
-      setTimer(timer + 1);
-      if (timer === timeOut - 1) {
-        setIsRunning(false);
-      }
-    },
-    isRunning ? 1000 : null,
-  );
   useEffect(() => {
-    if (change) {
-      if (start) {
+    if (start) {
+      if (timer < timeOut) {
         setIsRunning(true);
-        setChange(true);
       }
     }
   }, start);
-
+  useEffect(() => {
+    if (isRunning) {
+      const countdown = setInterval(() => {
+        setTimer(timer + 1);
+      }, 1000);
+      return () => {
+        clearInterval(countdown);
+        if (timer > timeOut - 2) {
+          setIsRunning(false);
+        }
+      };
+    }
+    return false;
+  }, [timer, isRunning]);
   return (
     <div className="flex-culomn">
-      <TextTimer time={timer} timeout={timeOut} />
-      <BarTimer time={timer} timeout={timeOut} isActive={isRunning} />
+      <TextTimer time={timeOut - timer} timeout={timeOut} />
+      <BarTimer timeout={timeOut} isActive={isRunning} />
     </div>
   );
 };


### PR DESCRIPTION
## GameSetting 추가
### 기능
- Redux에서 글자수를 가지고오고, `topic.json`에서 글자수에 맞는 리스트에서 데이터를 렌덤으로 가지고옴
- 준비 타이머가 끝나면 자동적으로 `/ingame`으로 이동함
###  topic.json
- 끄투온라인의 주제 단어와 한국어 능력시험 단어를 크롤링해서 제작함
```json
{
    "length2": [],
    "length3": [],
    "length4": [],
    "length5": [],
    "length6": [],
}
```
## Timer 관련 Issue
- `/ingame`에 3번째 접속시, `BarTime`가 실행이 안되는 Issue
- `BarTimer`의 타이머를 새로운 방식으로 변경하고, `timer`에 따라 progress가 진행되게 변경함